### PR TITLE
PR 

### DIFF
--- a/greent/conf/neo4j_types.yaml
+++ b/greent/conf/neo4j_types.yaml
@@ -43,9 +43,6 @@ phenotypic_feature:
   is_a:
     - disease_or_phenotypic_feature
 
-genetic_condition:
-  is_a:
-    - disease
 
 chemical_substance:
   is_a:

--- a/greent/services/gwascatalog.py
+++ b/greent/services/gwascatalog.py
@@ -155,7 +155,7 @@ class GWASCatalog(Service):
 
                                 if caid_count == 1:
                                     # multiple CAIDs per rsid makes precaching the rsid and caids in one call complex,
-                                    # here we can cache rsids that only returned one CAID easily, so do that
+                                    # here we can cache rsids that onl  y returned one CAID easily, so do that
                                     # others will meet synonymization later but it should be a small percentage of them
                                     # TODO we could/probably should split the synonyms returned for rsid calls then we could cache those cases too
                                     redis_pipe.set(f'synonymize(CAID:{caid_id})', pickle.dumps(synonyms))
@@ -228,7 +228,7 @@ class GWASCatalog(Service):
         if pubmed_id:
             pubs.append(f'PMID:{pubmed_id}')
 
-        predicate = LabeledID(identifier=f'gwascatalog:has_phenotype',label=f'has_phenotype')
+        predicate = LabeledID(identifier=f'RO:0002200',label=f'has_phenotype')
         edge = self.create_edge(
             variant_node, 
             phenotype_node, 

--- a/scripts/label_fix_normalization_miss.py
+++ b/scripts/label_fix_normalization_miss.py
@@ -5,7 +5,7 @@ class DBDriver:
     def __init__(self):
         neo4j_host = os.environ['NEO4J_HOST']
         neo4j_bolt = os.environ['NEO4J_BOLT_PORT']
-        neo4j_user = os.environ['NEO4J_USERNAME']
+        neo4j_user = 'neo4j'
         neo4j_password = os.environ['NEO4J_PASSWORD']
         self.driver = GraphDatabase.driver(
             uri=f'bolt://{neo4j_host}:{neo4j_bolt}',
@@ -24,15 +24,26 @@ def run_fix():
         'CARO': ':anatomical_entity:biological_entity:organismal_entity',
         'OMIM': ':biological_entity:disease:disease_or_phenotypic_feature',
         'DOID': ':biological_entity:disease:disease_or_phenotypic_feature',
-        'CP': ':anatomical_entity:cellular_component'
+        'CP': ':anatomical_entity:cellular_component',
+        'NCBIGene': ':gene:gene_or_gene_product:biological_entity:genomic_entity:macromolecular_machine:molecular_entity',
+        'UniProtKB': ':gene:gene_or_gene_product:biological_entity:genomic_entity:macromolecular_machine:molecular_entity',
+        'CHEMBL.COMPOUND': ':biological_entity:chemical_substance:molecular_entity',
+        'GTOPDB': ':biological_entity:chemical_substance:molecular_entity',
+        'HGNC': ':gene:gene_or_gene_product:biological_entity:genomic_entity:macromolecular_machine:molecular_entity',
+        'HMDB': ':biological_entity:chemical_substance:molecular_entity',
+        'PANTHER.FAMILY': ':gene_family',
+        'NCBITaxon': ':organism_taxon',
+        'NCBIGENE': ':gene:gene_or_gene_product:biological_entity:genomic_entity:macromolecular_machine:molecular_entity',
+        'UNIPROTKB': ':gene:gene_or_gene_product:biological_entity:genomic_entity:macromolecular_machine:molecular_entity'
     }
+
     make_query = lambda prefix, labels: f"MATCH (a) " \
         f"WHERE 1 = length(labels(a)) " \
         f"AND NOT a:Concept " \
         f"AND a.id STARTS WITH '{prefix}' " \
         f"SET a{labels} RETURN COUNT(a) as count"
 
-    for prefix, labels in fix_map:
+    for prefix, labels in fix_map.items():
         query = make_query(prefix, labels)
         print(f'running query \n {query}')
         count = db_driver.run(query).single()['count']


### PR DESCRIPTION
* Support for cli args for cord19 builder , adding provided by through cli.
* fix for export labels bug. 
   -  removed genetic condition from neo4j_types 
   - missed curies are written to file
   - export_graph.add labels is called if nodes don't have export labels assigned.
    - this will be overriden if the node normalization knows about it and give out a type.